### PR TITLE
Allow brew tap to build head if required

### DIFF
--- a/Formula/pygmy.rb
+++ b/Formula/pygmy.rb
@@ -6,27 +6,22 @@ class Pygmy < Formula
   desc "amazee.io's local development helper tool"
   homepage "https://github.com/pygmystack/pygmy"
   version "0.11.0"
+
   head do
     url "https://github.com/pygmystack/pygmy.git", branch: "main"
     depends_on "go" => :build if build.head?
   end
-
+  
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_arm64.tar.gz"
       sha256 "dab3f61125297009e5dfb0ec000e75cfd990375e91670f316d8b64d639d4422b"
 
-      def install
-        bin.install "pygmy"
-      end
     end
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_amd64.tar.gz"
       sha256 "281d374d7170eacfd9d28e772f31bd991c90e98459d7d65a918e104274d65bb9"
 
-      def install
-        bin.install "pygmy"
-      end
     end
   end
 
@@ -35,28 +30,26 @@ class Pygmy < Formula
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_amd64.tar.gz"
       sha256 "12c908f485a4ab244871af46f143a167c42afc818f577376905f99e3b8c18b1d"
       
-      def install
-        bin.install "pygmy"
-      end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm64.tar.gz"
       sha256 "048f6d0659f82a8b1688be35b2e8785f3e602098310b2ad25ce62004164f2041"
 
-      def install
-        bin.install "pygmy"
-      end
     end
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm.tar.gz"
       sha256 "e5eb069d1b4b25c0fa35d13389d5d8b9996abadad3a078700dee0b65cff2f8b1"
 
-      def install
-        bin.install "pygmy"
-      end
     end
   end
 
+  def install
+    if build.head?
+        system "go", "build", "-o", "pygmy"
+    end
+    bin.install "pygmy"
+  end
+  
   test do
     system "#{bin}/pygmy version"
   end

--- a/Formula/pygmy.rb
+++ b/Formula/pygmy.rb
@@ -11,6 +11,7 @@ class Pygmy < Formula
     if Hardware::CPU.arm?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_arm64.tar.gz"
       sha256 "dab3f61125297009e5dfb0ec000e75cfd990375e91670f316d8b64d639d4422b"
+      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -19,6 +20,7 @@ class Pygmy < Formula
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_amd64.tar.gz"
       sha256 "281d374d7170eacfd9d28e772f31bd991c90e98459d7d65a918e104274d65bb9"
+      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -30,6 +32,7 @@ class Pygmy < Formula
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_amd64.tar.gz"
       sha256 "12c908f485a4ab244871af46f143a167c42afc818f577376905f99e3b8c18b1d"
+      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -38,6 +41,7 @@ class Pygmy < Formula
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm64.tar.gz"
       sha256 "048f6d0659f82a8b1688be35b2e8785f3e602098310b2ad25ce62004164f2041"
+      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -46,6 +50,7 @@ class Pygmy < Formula
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm.tar.gz"
       sha256 "e5eb069d1b4b25c0fa35d13389d5d8b9996abadad3a078700dee0b65cff2f8b1"
+      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"

--- a/Formula/pygmy.rb
+++ b/Formula/pygmy.rb
@@ -6,7 +6,10 @@ class Pygmy < Formula
   desc "amazee.io's local development helper tool"
   homepage "https://github.com/pygmystack/pygmy"
   version "0.11.0"
-  head "https://github.com/pygmystack/pygmy.git", branch: "main"
+  head do
+    url "https://github.com/pygmystack/pygmy.git", branch: "main"
+    depends_on "go" => :build if build.head?
+  end
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/pygmy.rb
+++ b/Formula/pygmy.rb
@@ -16,12 +16,10 @@ class Pygmy < Formula
     if Hardware::CPU.arm?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_arm64.tar.gz"
       sha256 "dab3f61125297009e5dfb0ec000e75cfd990375e91670f316d8b64d639d4422b"
-
     end
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_amd64.tar.gz"
       sha256 "281d374d7170eacfd9d28e772f31bd991c90e98459d7d65a918e104274d65bb9"
-
     end
   end
 
@@ -29,17 +27,14 @@ class Pygmy < Formula
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_amd64.tar.gz"
       sha256 "12c908f485a4ab244871af46f143a167c42afc818f577376905f99e3b8c18b1d"
-      
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm64.tar.gz"
       sha256 "048f6d0659f82a8b1688be35b2e8785f3e602098310b2ad25ce62004164f2041"
-
     end
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm.tar.gz"
       sha256 "e5eb069d1b4b25c0fa35d13389d5d8b9996abadad3a078700dee0b65cff2f8b1"
-
     end
   end
 

--- a/Formula/pygmy.rb
+++ b/Formula/pygmy.rb
@@ -6,12 +6,12 @@ class Pygmy < Formula
   desc "amazee.io's local development helper tool"
   homepage "https://github.com/pygmystack/pygmy"
   version "0.11.0"
+  head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_arm64.tar.gz"
       sha256 "dab3f61125297009e5dfb0ec000e75cfd990375e91670f316d8b64d639d4422b"
-      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -20,7 +20,6 @@ class Pygmy < Formula
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_darwin_amd64.tar.gz"
       sha256 "281d374d7170eacfd9d28e772f31bd991c90e98459d7d65a918e104274d65bb9"
-      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -32,8 +31,7 @@ class Pygmy < Formula
     if Hardware::CPU.intel?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_amd64.tar.gz"
       sha256 "12c908f485a4ab244871af46f143a167c42afc818f577376905f99e3b8c18b1d"
-      head "https://github.com/pygmystack/pygmy.git", branch: "main"
-
+      
       def install
         bin.install "pygmy"
       end
@@ -41,7 +39,6 @@ class Pygmy < Formula
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm64.tar.gz"
       sha256 "048f6d0659f82a8b1688be35b2e8785f3e602098310b2ad25ce62004164f2041"
-      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"
@@ -50,7 +47,6 @@ class Pygmy < Formula
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/pygmystack/pygmy/releases/download/v0.11.0/pygmy_0.11.0_linux_arm.tar.gz"
       sha256 "e5eb069d1b4b25c0fa35d13389d5d8b9996abadad3a078700dee0b65cff2f8b1"
-      head "https://github.com/pygmystack/pygmy.git", branch: "main"
 
       def install
         bin.install "pygmy"


### PR DESCRIPTION
Here is a super low tech implementation of a head-building pygmy tap. I've used this in a github action successfully.